### PR TITLE
Extend the module to allow running non-default app

### DIFF
--- a/bottledaemon/bottledaemon.py
+++ b/bottledaemon/bottledaemon.py
@@ -25,11 +25,12 @@ def __locked_pidfile(filename):
     lock.release()
 
 
-def daemon_run(host="localhost", port="8080", pidfile=None, logfile=None):
+def daemon_run(app=None, host="localhost", port="8080", pidfile=None, logfile=None):
     """
     Get the bottle 'run' function running in the background as a daemonized
     process. 
 
+    :app: The app to use. If no value provided uses the default app.
     :host: The host interface to listen for connections on. Enter 0.0.0.0
            to listen on all interfaces. Defaults to localhost.
     :port: The host port to listen on. Defaults to 8080.
@@ -40,6 +41,9 @@ def daemon_run(host="localhost", port="8080", pidfile=None, logfile=None):
     parser = argparse.ArgumentParser()
     parser.add_argument("action", choices=["start", "stop"])
     args = parser.parse_args()
+
+    if app is None:
+        app = bottle.default_app()
 
     if pidfile is None:
         pidfile = os.path.join(
@@ -62,7 +66,7 @@ def daemon_run(host="localhost", port="8080", pidfile=None, logfile=None):
         )
         
         with context:
-            bottle.run(host=host, port=port)
+            bottle.run(app=app, host=host, port=port)
     else:
         with open(pidfile,"r") as p:
             pid = int(p.read())

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='BottleDaemon',
-    version='0.1.1',
+    version='0.1.3',
     author='Jonathan Hood',
     author_email='me@jonathanhood.org',
     packages=['bottledaemon'],


### PR DESCRIPTION
It's a small change and does not break the existing consumers. If no app is provided, the app returned by a call to the default_app() method will be used.

I wasn't sure about the version, so increased it to 0.1.3 from 0.1.2 as per https://pypi.python.org/pypi/BottleDaemon 
